### PR TITLE
🚀 build 실패 원인 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm run build
+        run: CI='' npm run build
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/src/components/Janggi/Referee.tsx
+++ b/src/components/Janggi/Referee.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Piece } from '@models/Piece';
 import { Position } from '@models/Position';


### PR DESCRIPTION
`Treating warnings as errors because process.env.CI = true. Most CI servers set it automatically.`라는 에러를 해결하기 위해 `deploy.yml`의 `npm run build`를 `CI='' npm run build`로 수정